### PR TITLE
Added spectral angle calculations

### DIFF
--- a/pbinternal2/report/eol_qc_stats.py
+++ b/pbinternal2/report/eol_qc_stats.py
@@ -45,10 +45,16 @@ def spectralAngle(a, b):
     return atan(a/b)*180/pi
 
 def calcSpectralAngles(movieDir):
+    """Calculates the spectral angles EOL QC uses
+    The story behind why these angles are calculated this way and how they came to be an important metric in the final
+    chip grading is a mystery. Followup discussion is in https://jira.pacificbiosciences.com/browse/ITG-93
+
+    :param movieDir: Directory with all of the movie files exported by the instrument
+    :return: green, red and final spectral angles
+    """
     for filename in [f for f in glob('%s/traceSplit/*.log' % movieDir)]:
         with open(filename) as file:
             for line in file:
-                # follow the example calculation
                 for match in re.finditer(pattern, line):
                     gG,rG,gR,rR = [float(num) for num in match.groups()]
                     greenAngle = spectralAngle(gR, gG)


### PR DESCRIPTION
CC @evolvedmicrobe 

This is work for ITG-89. It adds the spectral angle information to match what Remy is used to using.

Here is an example command to run this:

```
python pbinternal2/report/eol_qc_stats.py /pbi/collections/312/3120169/r54009_20160817_204720/29_F01/m54009_160818_103853.subreadset.xml /pbi/dept/secondary/siv/smrtlink/smrtlink-internal/userdata/jobs-root/000/000595/tasks/pbcoretools.tasks.gather_alignmentset-1/file.alignmentset.xml jf_test_prefix --nreads 16
```

And you'll see that the spreadsheet now includes spectral angles in the expected columns.

<img width="225" alt="screen shot 2016-08-30 at 3 53 00 pm" src="https://cloud.githubusercontent.com/assets/855834/18104588/db4173e0-6ec9-11e6-83bc-f811f418ad92.png">

See ITG-89 for a stand alone copy-paste of the code that matches the manually tested example there.