### PR TITLE
Add inst, sig process versions and sample well name to movies.csv

### DIFF
--- a/pbinternal2/report/eol_qc_stats.py
+++ b/pbinternal2/report/eol_qc_stats.py
@@ -292,6 +292,8 @@ def eol_qc_movie_stats(sset, aset, outcsv, nproc=1):
               'Green Angle',
               'Red Angle',
               'Spectral Angle',
+              'ICS Version',
+              'Sample Well Name',
               ]
     # TODO (mdsmith)(7-14-2016): Clean this up, use per external-resouce
     # sts.xml accessor
@@ -405,8 +407,11 @@ def eol_qc_movie_stats(sset, aset, outcsv, nproc=1):
                        'SnrDist']['G'][0].sampleMean)
         row.append(sset.metadata.summaryStats.channelDists[
                        'SnrDist']['T'][0].sampleMean)
-        # TODO: these three need to be calculated
         row.extend(formatSpectralAngles(os.path.dirname(sset.toExternalFiles()[0])))
+        # TODO: pull these from the meta-data
+        #row.append(sset.metadata.collections[0].)
+        row.append('')
+        row.append('')
 
         csv.append(row)
     log.info("Movie info processing time: {:}".format(time.clock() - start))

--- a/pbinternal2/report/eol_qc_stats.py
+++ b/pbinternal2/report/eol_qc_stats.py
@@ -293,6 +293,7 @@ def eol_qc_movie_stats(sset, aset, outcsv, nproc=1):
               'Red Angle',
               'Spectral Angle',
               'ICS Version',
+              'Signal Processing Version',
               'Sample Well Name',
               ]
     # TODO (mdsmith)(7-14-2016): Clean this up, use per external-resouce
@@ -408,10 +409,12 @@ def eol_qc_movie_stats(sset, aset, outcsv, nproc=1):
         row.append(sset.metadata.summaryStats.channelDists[
                        'SnrDist']['T'][0].sampleMean)
         row.extend(formatSpectralAngles(os.path.dirname(sset.toExternalFiles()[0])))
-        # TODO: pull these from the meta-data
-        #row.append(sset.metadata.collections[0].)
-        row.append('')
-        row.append('')
+        # inst control version
+        row.append(sset.metadata.collections[0].instCtrlVer)
+        # signal processing version
+        row.append(sset.metadata.collections[0].sigProcVer)
+        # sample name. e.g. VP52047-14_4754_BA020367_54097_2kLambda_200pM_LPTitration_Cell-5_12mW_Magbead
+        row.append(sset.metadata.collections[0].wellSample.name)
 
         csv.append(row)
     log.info("Movie info processing time: {:}".format(time.clock() - start))


### PR DESCRIPTION
Fixes [ITG-88|https://jira.pacificbiosciences.com/browse/ITG-88]. This is a quick one that pulls some meta-data that is already easily accessible in the CSV exporting code.

<img width="680" alt="screen shot 2016-08-31 at 10 52 15 am" src="https://cloud.githubusercontent.com/assets/855834/18133919/723022a6-6f6a-11e6-8832-61cfb63f104e.png">


CC @evolvedmicrobe, @mpkocher just a heads up. This one is so quick that I'm merging as is. I confirmed it worked via screenshot above.