### PR TITLE
Added median HqBasPkMid

### DIFF
--- a/pbinternal2/report/eol_qc_stats.py
+++ b/pbinternal2/report/eol_qc_stats.py
@@ -394,11 +394,15 @@ def eol_qc_movie_stats(sset, aset, outcsv, nproc=1):
                        'HqBasPkMidDist']['G'][0].sampleMean)
         row.append(sset.metadata.summaryStats.channelDists[
                        'HqBasPkMidDist']['T'][0].sampleMean)
-        # pkmedian -- TODO: check these are supposed to be medians. Above dist is continuous -- no median!
-        row.append('')
-        row.append('')
-        row.append('')
-        row.append('')
+        # pkmedian
+        row.append(sset.metadata.summaryStats.channelDists[
+                       'HqBasPkMidDist']['A'][0].sampleMed)
+        row.append(sset.metadata.summaryStats.channelDists[
+                       'HqBasPkMidDist']['C'][0].sampleMed)
+        row.append(sset.metadata.summaryStats.channelDists[
+                       'HqBasPkMidDist']['G'][0].sampleMed)
+        row.append(sset.metadata.summaryStats.channelDists[
+                       'HqBasPkMidDist']['T'][0].sampleMed)
         # SNR
         row.append(sset.metadata.summaryStats.channelDists[
                        'SnrDist']['A'][0].sampleMean)


### PR DESCRIPTION
Fixes [ITG-90|https://jira.pacificbiosciences.com/browse/ITG-90]. Another quick one. After looking closer at the meta-data and code, these median values are saved alongside the mean values. 

I spot checked the CSV output to confirm.

<img width="776" alt="screen shot 2016-08-31 at 11 18 10 am" src="https://cloud.githubusercontent.com/assets/855834/18134704/45fe2ed2-6f6d-11e6-8a2e-18a2610b3f8b.png">
