### PR TITLE
Fixes ITG-144 error

### DIFF
--- a/pbinternal2/report/eol_qc_stats.py
+++ b/pbinternal2/report/eol_qc_stats.py
@@ -493,13 +493,10 @@ def run(args):
     log.info("Starting movie analysis")
     eol_qc_movie_stats(args.subreadset, args.alignmentset,
                        '.'.join([args.outprefix, 'movies', 'csv']))
-    try:
-        args.sampler(args.alignmentset, args.nreads)
-        log.info("Starting zmw analysis")
-        eol_qc_zmw_stats(args.alignmentset,
-                         '.'.join([args.outprefix, 'zmws', 'csv']))
-    except:
-      log.error("Can't make per ZMW stats")
+    args.sampler(args.alignmentset, args.nreads)
+    log.info("Starting zmw analysis")
+    eol_qc_zmw_stats(args.alignmentset,
+                     '.'.join([args.outprefix, 'zmws', 'csv']))
     return 0
 
 def get_parser():

--- a/pbinternal2/report/eol_qc_stats.py
+++ b/pbinternal2/report/eol_qc_stats.py
@@ -31,7 +31,7 @@ def or_empty_string(f):
     def wrapper(*args, **kwargs):
         try:
             return f(*args, **kwargs)
-        except IOError:
+        except (IOError, ValueError):
             return ""
     return wrapper
 
@@ -207,6 +207,7 @@ def blocked_loading(aset, dims=(10, 8)):
     z = count_aligns(aset, chunks)
     return z, dims
 
+@or_empty_string
 def loading_efficiency(aset):
     # this was taken from the R code:
     # but there is currently a small discrepancy
@@ -492,10 +493,13 @@ def run(args):
     log.info("Starting movie analysis")
     eol_qc_movie_stats(args.subreadset, args.alignmentset,
                        '.'.join([args.outprefix, 'movies', 'csv']))
-    args.sampler(args.alignmentset, args.nreads)
-    log.info("Starting zmw analysis")
-    eol_qc_zmw_stats(args.alignmentset,
-                     '.'.join([args.outprefix, 'zmws', 'csv']))
+    try:
+        args.sampler(args.alignmentset, args.nreads)
+        log.info("Starting zmw analysis")
+        eol_qc_zmw_stats(args.alignmentset,
+                         '.'.join([args.outprefix, 'zmws', 'csv']))
+    except:
+      log.error("Can't make per ZMW stats")
     return 0
 
 def get_parser():


### PR DESCRIPTION
See https://jira.pacificbiosciences.com/browse/ITG-144

Some of the movies fail when making the per-ZMW metrics. It appears because of low quality data, but I didn't examine it too closely. Many movies work as expected and some have this error. CSVs now are generated for all movies.

Tested locally with `pbinternals` virtualenv and the following.

```
# test on a previously failing job
python pbinternal2/report/eol_qc_stats.py --nreads 32768 /pbi/collections/320/3200029/r54010_20160610_232022/19_D01/m54010_160611_085142.subreadset.xml /pbi/dept/itg/smrtlink-chips/jobs-root/000/000236/tasks/pbalign.tasks.pbalign-0/mapped.alignmentset.xml expected_to_fail

# previously working movies still work
python pbinternal2/report/eol_qc_stats.py --nreads 32768 /pbi/collections/320/3200036/r54010_20160903_193353/20_D01/m54010_160904_052654.subreadset.xml /pbi/dept/itg/smrtlink-chips/jobs-root/000/000011/tasks/pbalign.tasks.pbalign-0/mapped.alignmentset.xml should_still_work
```