### PR TITLE
Fix ITG-145. Add deploy version of the "frozen" code.

### DIFF
--- a/pbinternal2/__init__.py
+++ b/pbinternal2/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (3, 0, 3)
+VERSION = (3, 0, 4)
 
 
 TOOL_NAMESPACE = "pbinternal2"

--- a/pbinternal2/report/eol_qc_stats.py
+++ b/pbinternal2/report/eol_qc_stats.py
@@ -249,6 +249,11 @@ def loading_efficiency(aset):
     return penalty
 
 def eol_qc_movie_stats(sset, aset, outcsv, nproc=1):
+    # pull the "frozen" host and version from ENV
+    if 'SMRTLINK_HOST' not in os.environ or 'SMRTLINK_VERSION' not in os.environ:
+        raise ValueError("Must set SMRTLINK_HOST and SMRTLINK_VERSION env variables to note 'frozen' version of the code")
+    smrtlink_host = os.environ['SMRTLINK_HOST']
+    smrtlink_version = os.environ['SMRTLINK_VERSION']
     csv = []
     start = time.clock()
     # Rearranged as per Remy's list in ITG-85: https://jira.pacificbiosciences.com/browse/ITG-85
@@ -310,6 +315,7 @@ def eol_qc_movie_stats(sset, aset, outcsv, nproc=1):
               'Sample Well Name',
               'sts.xml Windows',
               'sts.xml POSIX',
+              smrtlink_host
               ]
     # TODO (mdsmith)(7-14-2016): Clean this up, use per external-resouce
     # sts.xml accessor
@@ -440,6 +446,8 @@ def eol_qc_movie_stats(sset, aset, outcsv, nproc=1):
         sts_path = '%s.sts.xml' % sset.fileNames[0].replace('.subreadset.xml', '')
         row.append('\\%s' % sts_path.replace('/', '\\'))
         row.append(sts_path)
+        # smrtlink deploy version -- the "frozen" software
+        row.append(smrtlink_version)
 
         csv.append(row)
     log.info("Movie info processing time: {:}".format(time.clock() - start))


### PR DESCRIPTION
Fixes ITG-145. 

Tested with

```bash
export SMRTLINK_HOST="smrtlink-test"
export SMRTLINK_VERSION="0.0.2"

python pbinternal2/report/eol_qc_stats.py --nreads 32768 /pbi/collections/320/3200029/r54010_20160610_232022/19_D01/m54010_160611_085142.subreadset.xml /pbi/dept/itg/smrtlink-chips/jobs-root/000/000236/tasks/pbalign.tasks.pbalign-0/mapped.alignmentset.xml example
```

And confirmed the output in `example.movies.csv`.