### PR TITLE
Fixes for ITG-178 and running the code outside Ansible deploys

### DIFF
--- a/pbinternal2/__init__.py
+++ b/pbinternal2/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (3, 0, 4)
+VERSION = (3, 0, 5)
 
 
 TOOL_NAMESPACE = "pbinternal2"

--- a/pbinternal2/report/eol_qc_stats.py
+++ b/pbinternal2/report/eol_qc_stats.py
@@ -251,9 +251,9 @@ def loading_efficiency(aset):
 def eol_qc_movie_stats(sset, aset, outcsv, nproc=1):
     # pull the "frozen" host and version from ENV
     if 'SMRTLINK_HOST' not in os.environ or 'SMRTLINK_VERSION' not in os.environ:
-        raise ValueError("Must set SMRTLINK_HOST and SMRTLINK_VERSION env variables to note 'frozen' version of the code")
-    smrtlink_host = os.environ['SMRTLINK_HOST']
-    smrtlink_version = os.environ['SMRTLINK_VERSION']
+        log.warn("Must set SMRTLINK_HOST and SMRTLINK_VERSION env variables to note 'frozen' version of the code")
+    smrtlink_host = os.environ['SMRTLINK_HOST'] if 'SMRTLINK_HOST' in os.environ else 'smrtlink-host'
+    smrtlink_version = os.environ['SMRTLINK_VERSION'] if 'SMRTLINK_VERSION' in os.environ else  ''
     csv = []
     start = time.clock()
     # Rearranged as per Remy's list in ITG-85: https://jira.pacificbiosciences.com/browse/ITG-85


### PR DESCRIPTION
Title says most all of it. See ITG-178 for more details.

Tested locally by similar strategy to #31 but with a dataset from the Surface group.

```
# load the VENV and PYTHONPATH
source ENV/bin/activate
export PYTHONPATH=.:PYTHONPATH

# Run the script directory on ITG-178 data sets. In this case `http://smrtlink-internal:8080/#/analysis/job/5338`.
python pbinternal2/report/eol_qc_stats.py --nreads 32768 /pbi/collections/319/3190006/r54010_20161011_231134/1_A01/m54010_161011_231148.subreadset.xml /pbi/dept/secondary/siv/smrtlink/smrtlink-internal/userdata/jobs-root/005/005338/tasks/pbalign.tasks.consolidate_alignments-0/combined.alignmentset.xml  m54010_161011_231148
```